### PR TITLE
Add semgrep configuration

### DIFF
--- a/.github/workflows/static-scan.yml
+++ b/.github/workflows/static-scan.yml
@@ -1,0 +1,25 @@
+# Name of this GitHub Actions workflow.
+name: Semgrep
+
+on:
+  # Scan changed files in PRs, only report new findings (existing findings in the repository are ignored).
+  pull_request: {}
+jobs:
+  semgrep:
+    # User definable name of this GitHub Actions job.
+    name: Scan
+    runs-on: ubuntu-latest
+    container:
+      # A Docker image with Semgrep installed. Don't change this.
+      image: returntocorp/semgrep
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      # Fetch project source with GitHub Actions Checkout.
+      - uses: actions/checkout@v3
+
+      # Run the "semgrep ci" command on the command line of the docker image.
+      - run: semgrep ci
+        env:
+          # Set hard-coded rulesets, viewable in logs.
+          SEMGREP_RULES: p/default # more at semgrep.dev/explore


### PR DESCRIPTION
Add semgrep configuration for a workflow

*Issue #, if available:*

N/A

*Description of changes:*

This adds semgrep, a static code analyzer, as a workflow on new pull requests.

The default ruleset is defined here: https://semgrep.dev/p/default 


Based on the code: https://github.com/aws/rolesanywhere-credential-helper/blob/4aaa70626c9361bf7bb4d6d91e85b5e1ce242cce/.github/workflows/semgrep.yml#L20


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
