### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   scan-for-secrets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout PR code


### PR DESCRIPTION
Potential fix for [https://github.com/aws/nova-customization-sdk/security/code-scanning/10](https://github.com/aws/nova-customization-sdk/security/code-scanning/10)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow or to individual jobs, granting only the minimal required scopes. For a typical read-only scanning workflow that checks out code and reads PR metadata, `contents: read` (and optionally `pull-requests: read`) is sufficient. This both enforces least privilege and documents the workflow’s needs, independent of organization/repository defaults.

For this specific workflow in `.github/workflows/git-secrets-scan.yml`, the best fix without changing existing functionality is to add a `permissions` block at the job level for `scan-for-secrets`. The job uses `actions/checkout` and reads from the event payload; it does not push commits, comment on PRs, or modify any GitHub resources, so write permissions are unnecessary. We will therefore add:

```yaml
permissions:
  contents: read
```

under the `scan-for-secrets` job (e.g., between `runs-on: ubuntu-latest` and `steps:`). No additional methods, imports, or definitions are required, since this is purely a YAML configuration change. Only `.github/workflows/git-secrets-scan.yml` needs to be edited, and only in the shown region around the job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
