### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/aws/nova-customization-sdk/security/code-scanning/5](https://github.com/aws/nova-customization-sdk/security/code-scanning/5)

In general, to fix this type of issue you explicitly define a `permissions` block either at the top level of the workflow (to apply to all jobs) or within specific jobs, granting only the scopes actually required. This prevents the workflow from inheriting broader default permissions that might allow unintended write operations via `GITHUB_TOKEN`.

For this specific workflow, no step performs write operations against the repository or GitHub APIs; it only checks out code and runs local build/test commands. Therefore, the single best fix without changing behavior is to add a workflow-level `permissions` block with read-only contents access, e.g. `permissions: { contents: read }`. This should be placed after the `on:` block (e.g., after line 25) and before `jobs:` so it applies to all jobs in the workflow, including the existing `build` job. No additional imports, methods, or other definitions are needed—just the YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
