### PR TITLE
fix: include JSON and YAML files in wheel distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@
        "wheel",
      ]
 
+     [tool.setuptools.package-data]
+     amzn_nova_customization_sdk = ["**/*.json", "**/*.yaml"]
+
      [tool.setuptools.dynamic]
      version = {attr = "amzn_nova_customization_sdk.__version__.VERSION"}
      dependencies = {file = "requirements.txt"}


### PR DESCRIPTION
## Summary
This PR adds `[tool.setuptools.package-data]` configuration to ensure IAM policy JSON files and recipe template YAML files are included in the wheel distribution.

## Problem
Without this configuration, the following files are not packaged in the wheel:
- `iam/bedrock_policies.json`
- `iam/sagemaker_policies.json`
- `rft_multiturn/rft_multiturn_policies.json`
- `recipe/templates/override/*.json`
- `recipe/templates/recipe/*.yaml`

This causes `create_bedrock_execution_role()` and `create_sagemaker_execution_role()` functions to fail at runtime when the SDK is installed from PyPI.

## Root Cause
The `pyproject.toml` was missing `package-data` configuration, so setuptools only included `.py` files by default.

## Fix
Added:
```toml
[tool.setuptools.package-data]
amzn_nova_customization_sdk = ["**/*.json", "**/*.yaml"]
```

## Test Plan
- [x] Built wheel with `python -m build --wheel`
- [x] Verified JSON and YAML files are included in wheel:
  ```
  amzn_nova_customization_sdk/iam/bedrock_policies.json
  amzn_nova_customization_sdk/iam/sagemaker_policies.json
  amzn_nova_customization_sdk/recipe/templates/override/*.json (4 files)
  amzn_nova_customization_sdk/recipe/templates/recipe/*.yaml (4 files)
  amzn_nova_customization_sdk/rft_multiturn/rft_multiturn_policies.json
  ```
- [x] Installed wheel and verified `importlib.resources` can load policy files at runtime

Fixes #31